### PR TITLE
Fix 'Legend' and 'Ancient' being switched

### DIFF
--- a/ranktier/__init__.py
+++ b/ranktier/__init__.py
@@ -20,8 +20,8 @@ def getrank(rank):
             , "2" : "Guardian"
             , "3" : "Crusader"
             , "4" : "Archon"
-            , "5" : "Ancient"
-            , "6" : "Legend"
+            , "5" : "Legend"
+            , "6" : "Ancient"
             , "7" : "Divine" }
 
     readable_rank.append("[%s]" % rank[1])


### PR DESCRIPTION
    >>> ranktier.ranktier(65)    # Ancient [5] would be correct
    Legend [5]

Legend is lower than Ancient, so the current order is wrong. This should fix it.

